### PR TITLE
refact: avoid importing python package neqsim

### DIFF
--- a/jneqsim/jvm_service.py
+++ b/jneqsim/jvm_service.py
@@ -29,4 +29,4 @@ if not jpype.isJVMStarted():
 import jpype.imports  # noqa
 
 # This is the java package, added to the python scope by "jpype.imports"
-import neqsim  # noqa (ruff wants to remove this line, since it's not used)
+neqsim = jpype.JPackage("neqsim")


### PR DESCRIPTION
when python package neqsim is already installed in the same environment, "import neqsim" will import the python package and not the java package. 