### PR TITLE
build: update jar pattern convention

### DIFF
--- a/jneqsim/common/config.yaml
+++ b/jneqsim/common/config.yaml
@@ -19,11 +19,12 @@ neqsim:
       base_url: "https://github.com/equinor/neqsim/releases/download"
       # JAR file patterns for different Java versions
       # Note: The code will try multiple naming patterns per Java version
-      # (e.g., Java21-Java21, Java21) to handle variations
+      # (e.g., Java21-Java21, Java21) to handle variations. Java21+ should use the unsuffixed jar
       assets:
         java8: "neqsim-{version}-Java8.jar"
-        java11: "neqsim-{version}.jar" # Java 11+ version
-        java21: "neqsim-{version}-Java21.jar"
+        java11: "neqsim-{version}-Java11.jar" 
+        java17: "neqsim-{version}-Java17.jar"
+        java21: "neqsim-{version}.jar"
 
 # Logging configuration
 logging:

--- a/jneqsim/dependency_manager.py
+++ b/jneqsim/dependency_manager.py
@@ -45,27 +45,29 @@ class NeqSimDependencyManager:
     def _get_jar_patterns(self, java_version: int) -> list[str]:
         """Get list of JAR filename patterns to try for a given Java version.
 
-        Returns patterns in order of preference, with newer patterns first.
-        Some releases use varying naming patterns (e.g., Java21-Java21 vs Java21).
+        Convention (as of NeqSim 3.12.x):
+            - The unsuffixed jar `neqsim-{version}.jar` targets the newest
+            supported Java (currently 21+).
+            - Older Java versions get a `-Java{N}` suffix, e.g.
+            `neqsim-{version}-Java8.jar`, `-Java11.jar`, `-Java17.jar`.
         """
         github_config = self.config["neqsim"]["sources"]["github"]
+        assets = github_config["assets"]
+        unsuffixed = assets.get("java21", "neqsim-{version}.jar")
 
         if java_version == 8:
-            return [
-                "neqsim-{version}-Java8-Java8.jar",  # Newer pattern
-                github_config["assets"]["java8"],  # Standard pattern
-            ]
-        elif 11 <= java_version < 21:
-            return [
-                "neqsim-{version}.jar",  # Standard pattern
-            ]
-        elif java_version >= 21:
-            return [
-                "neqsim-{version}-Java21-Java21.jar",  # Newer pattern
-                github_config["assets"]["java21"],  # Standard pattern
-            ]
-        else:
-            raise ValueError(f"Unsupported Java version: {java_version}")
+            return [assets["java8"]]
+        # Try explicit -Java11 first, fall back to Java8 jar (backward compatible)
+        if java_version == 11:
+            return [assets.get("java11", "neqsim-{version}-Java11.jar"), assets["java8"]]
+        # Try explicit -Java17 first, fall back to Java8 jar (backward compatible)
+        if java_version == 17:
+            return [assets.get("java17", "neqsim-{version}-Java17.jar"), assets["java8"]]
+        # Unsuffixed jar is built for the newest Java
+        if java_version >= 21:
+            return [unsuffixed]
+
+        raise ValueError(f"Unsupported Java version: {java_version}")
 
     def _get_jar_from_github(self, version: str, java_version: int) -> Path:
         """Download JAR from GitHub releases with fallback support and caching"""

--- a/tests/test_dependency_management.py
+++ b/tests/test_dependency_management.py
@@ -24,8 +24,9 @@ def test_config():
                     "base_url": "https://github.com/equinor/neqsim/releases/download",
                     "assets": {
                         "java8": "neqsim-{version}-Java8.jar",
-                        "java11": "neqsim-{version}.jar",
-                        "java21": "neqsim-{version}-Java21.jar",
+                        "java11": "neqsim-{version}-Java11.jar",
+                        "java17": "neqsim-{version}-Java17.jar",
+                        "java21": "neqsim-{version}.jar",
                     },
                 },
             },
@@ -88,7 +89,6 @@ class TestNeqSimDependencyManager:
 
         patterns = manager._get_jar_patterns(8)
         expected_patterns = [
-            "neqsim-{version}-Java8-Java8.jar",
             "neqsim-{version}-Java8.jar",
         ]
         assert patterns == expected_patterns
@@ -100,7 +100,8 @@ class TestNeqSimDependencyManager:
 
         patterns = manager._get_jar_patterns(11)
         expected_patterns = [
-            "neqsim-{version}.jar",
+            "neqsim-{version}-Java11.jar",
+            "neqsim-{version}-Java8.jar",
         ]
         assert patterns == expected_patterns
 
@@ -111,8 +112,18 @@ class TestNeqSimDependencyManager:
 
         patterns = manager._get_jar_patterns(21)
         expected_patterns = [
-            "neqsim-{version}-Java21-Java21.jar",
-            "neqsim-{version}-Java21.jar",
+            "neqsim-{version}.jar",
+        ]
+        assert patterns == expected_patterns
+
+    def test_jar_patterns_java25(self, temp_config_file, temp_cache_dir):
+        """Test JAR filename patterns for Java 25 (any future version >= 21 uses unsuffixed jar)."""
+        config = load_config(temp_config_file)
+        manager = NeqSimDependencyManager(config=config, cache_dir=temp_cache_dir)
+
+        patterns = manager._get_jar_patterns(25)
+        expected_patterns = [
+            "neqsim-{version}.jar",
         ]
         assert patterns == expected_patterns
 

--- a/tests/test_multiple_versions.py
+++ b/tests/test_multiple_versions.py
@@ -13,7 +13,7 @@ class TestMultipleJavaVersions:
         assert configured_version is not None
 
         # Test different Java versions
-        java_versions = [8, 11, 17, 21]
+        java_versions = [8, 11, 17, 21, 25]
 
         for java_version in java_versions:
             # Test that the manager can generate patterns for each version
@@ -74,8 +74,12 @@ class TestMultipleJavaVersions:
         patterns_8 = manager._get_jar_patterns(8)
         patterns_11 = manager._get_jar_patterns(11)
         patterns_21 = manager._get_jar_patterns(21)
+        patterns_25 = manager._get_jar_patterns(25)
 
-        # At least some patterns should be different
+        # Java 21 and 25 should use the same unsuffixed jar
+        assert patterns_21 == patterns_25, "Java 21 and 25 should use the same unsuffixed jar"
+
+        # At least some patterns should be different across versions
         all_patterns = [tuple(patterns_8), tuple(patterns_11), tuple(patterns_21)]
         assert len(set(all_patterns)) > 1, "Patterns should vary across Java versions"
 


### PR DESCRIPTION
This pull request updates the logic for selecting neqsim `.jar` files based on Java version, standardizing the "new" naming conventions and improving compatibility with future Java releases. The changes ensure that Java 21 and newer use the unsuffixed `.jar`, while older versions use explicit suffixes